### PR TITLE
Fix object name line

### DIFF
--- a/addons/CSGExport/csgexport.gd
+++ b/addons/CSGExport/csgexport.gd
@@ -50,7 +50,7 @@ func exportcsg():
 	
 	#OBJ Headers
 	objcont+="mtllib "+object_name+".mtl\n"
-	objcont+="o" + object_name + "\n";		"CHANGE WITH SELECTION NAME";
+	objcont+="o " + object_name + "\n";		"CHANGE WITH SELECTION NAME";
 	
 	
 	#Get surfaces and mesh info


### PR DESCRIPTION
The tag name line needed a space after 'o'.