### PR TITLE
Add default blank material to meshes

### DIFF
--- a/addons/CSGExport/csgexport.gd
+++ b/addons/CSGExport/csgexport.gd
@@ -52,6 +52,9 @@ func exportcsg():
 	objcont+="mtllib "+object_name+".mtl\n"
 	objcont+="o" + object_name + "\n";		"CHANGE WITH SELECTION NAME";
 	
+	#Blank material
+	var blank_material = SpatialMaterial.new()
+	blank_material.resource_name = "BlankMaterial"
 	
 	#Get surfaces and mesh info
 	for t in range(csgMesh[-1].get_surface_count()):
@@ -86,8 +89,10 @@ func exportcsg():
 		#add groups and materials
 		objcont+="g surface"+str(t)+"\n"
 		
-		if mat != null:
-			objcont+="usemtl "+str(mat)+"\n"
+		if mat == null:
+			mat = blank_material
+		
+		objcont+="usemtl "+str(mat)+"\n"
 		
 		#add faces
 		for face in faces:
@@ -97,12 +102,11 @@ func exportcsg():
 		#update verts
 		vertcount+=tempvcount
 		
-		if mat != null:
-			#create Materials for current surface
-			matcont+=str("newmtl "+str(mat))+'\n'
-			matcont+=str("Kd ",mat.albedo_color.r," ",mat.albedo_color.g," ",mat.albedo_color.b)+'\n'
-			matcont+=str("Ke ",mat.emission.r," ",mat.emission.g," ",mat.emission.b)+'\n'
-			matcont+=str("d ",mat.albedo_color.a)+"\n"
+		#create Materials for current surface
+		matcont+=str("newmtl "+str(mat))+'\n'
+		matcont+=str("Kd ",mat.albedo_color.r," ",mat.albedo_color.g," ",mat.albedo_color.b)+'\n'
+		matcont+=str("Ke ",mat.emission.r," ",mat.emission.g," ",mat.emission.b)+'\n'
+		matcont+=str("d ",mat.albedo_color.a)+"\n"
 		
 
 	#Write to files


### PR DESCRIPTION
When not using a material in a CSG Mesh but using in others, an entire mesh-face would use the material set before it in the Wavefront file. The fix adds a default blank material that is used whenever no material is set for the mesh.

Without fix:
![Screenshot_2020-04-26_18-13-36](https://user-images.githubusercontent.com/7095429/80320089-b959f980-87ea-11ea-9f52-61c9a26cfd0c.png)

With fix:
![Screenshot_2020-04-26_18-15-29](https://user-images.githubusercontent.com/7095429/80320104-c8d94280-87ea-11ea-8e11-4f85a5f40486.png)
